### PR TITLE
updated readme to include button type in form

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ class AccountScreen < PM::FormScreen
       }, {
         name: :submit,
         title: "Submit",
+        type: :button,
         action: "my_action:"
       }]
     }]


### PR DESCRIPTION
I was wondering why when I copied the example the button looked like it was a textfield.  Turns out the type was not specified in the example.
