### PR TITLE
remove #to_s on values with nil defaults

### DIFF
--- a/lib/ProMotion/form/form.rb
+++ b/lib/ProMotion/form/form.rb
@@ -39,7 +39,7 @@ module ProMotion
     end
 
     def values
-      fields.map{ |f| f[:value].to_s }
+      fields.map{ |f| f[:value] }
     end
 
     def form_fields


### PR DESCRIPTION
When you don't specify values for fields of type time or date, they blow up with an error message similar to:

```
-[String isEqualToDate:]: unrecognized selector sent to instance 0x171e7f10
```

This is because the default value from the gem was always being turned to `String` even when no default value was provided.

Please note, I was not actually able to run the tests locally. With the latest upgrade of RubyMotion and the version lock of the gem, something is happening, which I did not want to take the time to evaluate.
