### PR TITLE
Good defaults for cells with no values

### DIFF
--- a/app/test_screens/test_form_screen.rb
+++ b/app/test_screens/test_form_screen.rb
@@ -14,13 +14,16 @@ class TestFormScreen < PM::FormScreen
         name: "password",
         title: "Password",
         type: :password,
-        value: ""
+      }, {
+        name: "date",
+        title: "Date",
+        type: :date,
       }]
     }, {
       title: "Second Section",
       cells: [{
         title: "Cell Without A Name",
-        value: ""
+        value: "",
       }]
     }]
   end

--- a/lib/ProMotion/form/form.rb
+++ b/lib/ProMotion/form/form.rb
@@ -39,7 +39,7 @@ module ProMotion
     end
 
     def values
-      fields.map{ |f| f[:value] }
+      fields.map{ |f| get_value(f) }
     end
 
     def form_fields
@@ -58,6 +58,16 @@ module ProMotion
       data[:value] = input[:value] if input[:value]
       data[:action] = input[:action] if input[:action]
       data
+    end
+
+    def get_value(f)
+      f[:value] || begin
+        case f[:type]
+        when :date then NSDate.date
+        when :time then NSDate.date
+        else ""
+        end
+      end
     end
   end
 end

--- a/spec/unit_form_screen_spec.rb
+++ b/spec/unit_form_screen_spec.rb
@@ -21,7 +21,7 @@ describe "ProMotion::TestFormScreen unit" do
   end
 
   it "contains cells" do
-    form_controller.sections[0].fields.count.should == 2
+    form_controller.sections[0].fields.count.should == 3
     form_controller.sections[1].fields.count.should == 1
   end
 
@@ -31,6 +31,16 @@ describe "ProMotion::TestFormScreen unit" do
     field.class.should == FXFormField
     field.title.should == "Cell Without A Name"
     field.key.should == :cell_without_a_name
+  end
+
+  it "provides a sensible default for cells without a :value" do
+    field0 = form_controller.sections[0].fields[0]
+    field1 = form_controller.sections[0].fields[1]
+    field2 = form_controller.sections[0].fields[2]
+
+    field0.value.should == "jamon@example.com"
+    field1.value.should == ""
+    field2.value.to_s.should == NSDate.date.to_s
   end
 
 end


### PR DESCRIPTION
FXForms will crash if you give it the wrong value for a cell type. Because of that, we have to be a little smarter about what we give each cell for a default.

Ref: #13, #10.
