### PR TITLE
FXForms properties: keyboard type example added

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ class MyFormScreen < PM::FormScreen
         type: :password,
         "textLabel.color" => UIColor.blueColor,
         value: "",
+      },
+        name: "pin",
+        title: "PIN",
+        type: :password,
+        value: nil,
+        "textField.keyboardType" => UIKeyboardTypeNumberPad
       }]
     }]
   end


### PR DESCRIPTION
Thought this added example would be useful for people. No worries if you don't want to merge.
